### PR TITLE
build: fix multiple definitions

### DIFF
--- a/ip/ipmroute.c
+++ b/ip/ipmroute.c
@@ -44,7 +44,7 @@ static void usage(void)
 	exit(-1);
 }
 
-struct rtfilter {
+static struct rtfilter {
 	int tb;
 	int af;
 	int iif;

--- a/ip/xfrm_monitor.c
+++ b/ip/xfrm_monitor.c
@@ -34,7 +34,7 @@
 #include "ip_common.h"
 
 static void usage(void) __attribute__((noreturn));
-int listen_all_nsid;
+static int listen_all_nsid;
 
 static void usage(void)
 {

--- a/tipc/tipc.c
+++ b/tipc/tipc.c
@@ -22,10 +22,10 @@
 #include "node.h"
 #include "peer.h"
 #include "cmdl.h"
+#include "utils.h"
 
 int help_flag;
 int json;
-int pretty;
 
 static void about(struct cmdl *cmdl)
 {


### PR DESCRIPTION
Fix GCC release 10 being unable to compile iproute-mptcp because of multiple definition of functions.

```
/usr/bin/ld: ipxfrm.o:(.bss+0x0): multiple definition of `filter'; ipmroute.o:(.bss+0x0): first defined here
/usr/bin/ld: xfrm_monitor.o:(.bss+0x0): multiple definition of `listen_all_nsid'; ipmonitor.o:(.bss+0x0): first defined here
/usr/bin/ld: libutil.a(utils.o):(.bss+0xc): multiple definition of `pretty'; tipc.o:tipc.c:28: first defined here
```

References: https://bugzilla.opensuse.org/1160244

Signed-off-by: Arınç ÜNAL <arinc.unal@gmail.com>